### PR TITLE
Tagger and push rejection

### DIFF
--- a/src/main/java/com/rimerosolutions/ant/git/tasks/TagTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/TagTask.java
@@ -15,6 +15,9 @@
  */
 package com.rimerosolutions.ant.git.tasks;
 
+import com.rimerosolutions.ant.git.GitSettings;
+import com.rimerosolutions.ant.git.MissingRequiredGitSettingsException;
+
 import org.eclipse.jgit.api.errors.GitAPIException;
 
 import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
@@ -75,8 +78,14 @@ public class TagTask extends AbstractGitRepoAwareTask {
 
                 message = GitTaskUtils.BRANDING_MESSAGE + " " + message;
 
+                GitSettings gitSettings = lookupSettings();
+
+                if (gitSettings == null) {
+                        throw new MissingRequiredGitSettingsException();
+                }
+                
                 try {
-                        git.tag().setName(name).setMessage(message).call();
+                        git.tag().setName(name).setTagger(gitSettings.getIdentity()).setMessage(message).call();
                 } catch (GitAPIException ex) {
                         throw new GitBuildException(String.format(MESSAGE_TAG_CREATE_FAILED, name), ex);
                 }


### PR DESCRIPTION
Tagger was not set from git:settings (same as with committer previously) and I added detection of "Push rejected." in the push messages to fail the push (it's what we see in Stash when a server-side hook fails and for some reason the returned result does not trigger a fail by itself).