### PR TITLE
Push rejection detection using RemoteRefUpdate status

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.java text eol=lf

--- a/src/main/java/com/rimerosolutions/ant/git/GitTaskUtils.java
+++ b/src/main/java/com/rimerosolutions/ant/git/GitTaskUtils.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 import org.apache.tools.ant.BuildException;
 import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.transport.TrackingRefUpdate;
 
 /**
@@ -97,6 +98,27 @@ public final class GitTaskUtils {
                             result == RefUpdate.Result.REJECTED ||
                             result == RefUpdate.Result.REJECTED_CURRENT_BRANCH ) {
                                 throw new BuildException(String.format("%s - Status '%s'", errorPrefix, result.name()));
+                        }
+                }
+        }
+
+        /**
+         * Check references updates for any errors
+         *
+         * @param errorPrefix The error prefix for any error message
+         * @param refUpdates A collection of remote references updates
+         */
+        public static void validateRemoteRefUpdates(String errorPrefix, Collection<RemoteRefUpdate> refUpdates) {
+                for (RemoteRefUpdate refUpdate : refUpdates) {
+                        RemoteRefUpdate.Status status = refUpdate.getStatus();
+
+                        if (status == RemoteRefUpdate.Status.REJECTED_NODELETE ||
+                            status == RemoteRefUpdate.Status.NON_EXISTING ||
+                            status == RemoteRefUpdate.Status.NOT_ATTEMPTED ||
+                            status == RemoteRefUpdate.Status.REJECTED_NONFASTFORWARD ||
+                            status == RemoteRefUpdate.Status.REJECTED_OTHER_REASON ||
+                            status == RemoteRefUpdate.Status.REJECTED_REMOTE_CHANGED) {
+                                throw new BuildException(String.format("%s - Status '%s'", errorPrefix, status.name()));
                         }
                 }
         }

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/CommitTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/CommitTask.java
@@ -75,8 +75,8 @@ public class CommitTask extends AbstractGitRepoAwareTask {
          * @param brandedMessage Flag to use branded message
          */
         public void setBrandedMessage(boolean brandedMessage) {
-			this.brandedMessage = brandedMessage;
-		}
+                this.brandedMessage = brandedMessage;
+        }
 
         /**
          * Configure the fileset(s) of files to add to revision control
@@ -112,7 +112,7 @@ public class CommitTask extends AbstractGitRepoAwareTask {
                         CommitCommand cmd = git.commit();
 
                         if (!GitTaskUtils.isNullOrBlankString(message)) {
-                                cmd.setMessage(brandedMessage?GitTaskUtils.BRANDING_MESSAGE + " ":"" + message);
+                                cmd.setMessage(brandedMessage ? GitTaskUtils.BRANDING_MESSAGE + " " : "" + message);
                         }
                         else {
                                 cmd.setMessage(GitTaskUtils.BRANDING_MESSAGE);
@@ -141,7 +141,7 @@ public class CommitTask extends AbstractGitRepoAwareTask {
                                 throw new MissingRequiredGitSettingsException();
                         }
 
-			cmd.setAmend(amend).setAuthor(gitSettings.getIdentity()).setCommitter(gitSettings.getIdentity());
+                        cmd.setAmend(amend).setAuthor(gitSettings.getIdentity()).setCommitter(gitSettings.getIdentity());
 
                         if (reflogComment != null) {
                                 cmd.setReflogComment(reflogComment);
@@ -157,8 +157,7 @@ public class CommitTask extends AbstractGitRepoAwareTask {
                         log(revCommit.getFullMessage());
                 } catch (IOException ioe) {
                         throw new GitBuildException(MESSAGE_COMMIT_FAILED, ioe);
-                }
-                catch (GitAPIException ex) {
+                } catch (GitAPIException ex) {
                         throw new GitBuildException(MESSAGE_COMMIT_FAILED, ex);
                 }
         }

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/CommitTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/CommitTask.java
@@ -17,11 +17,6 @@ package com.rimerosolutions.ant.git.tasks;
 
 import java.io.IOException;
 
-import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
-import com.rimerosolutions.ant.git.GitBuildException;
-import com.rimerosolutions.ant.git.GitSettings;
-import com.rimerosolutions.ant.git.GitTaskUtils;
-import com.rimerosolutions.ant.git.MissingRequiredGitSettingsException;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.resources.Union;
@@ -29,6 +24,12 @@ import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
+
+import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
+import com.rimerosolutions.ant.git.GitBuildException;
+import com.rimerosolutions.ant.git.GitSettings;
+import com.rimerosolutions.ant.git.GitTaskUtils;
+import com.rimerosolutions.ant.git.MissingRequiredGitSettingsException;
 
 /**
  * Commits all local changes.

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/GitTasks.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/GitTasks.java
@@ -19,11 +19,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+
 import com.rimerosolutions.ant.git.GitTask;
 import com.rimerosolutions.ant.git.GitTaskMonitor;
 import com.rimerosolutions.ant.git.GitTaskUtils;
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Task;
 
 /**
  * Git tasks container.

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/GitTasks.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/GitTasks.java
@@ -138,11 +138,11 @@ public class GitTasks extends Task {
                 return c;
         }
 
-    /**
-         * Creates a nested <code>branch</code> task.
-         *
-         * @return a new branch task.
-         */
+        /**
+             * Creates a nested <code>branch</code> task.
+             *
+             * @return a new branch task.
+             */
         public BranchTask createBranch() {
                 BranchTask c = new BranchTask();
                 tasks.add(c);
@@ -246,17 +246,17 @@ public class GitTasks extends Task {
                 return p;
         }
 
-	/**
-	 * Creates a nested <code>merge</code> task.
-	 *
-	 * @return a new task to merge changes.
-	 */
-	public MergeTask createMerge() {
-		MergeTask m = new MergeTask();
-		tasks.add(m);
+        /**
+         * Creates a nested <code>merge</code> task.
+         *
+         * @return a new task to merge changes.
+         */
+        public MergeTask createMerge() {
+                MergeTask m = new MergeTask();
+                tasks.add(m);
 
-		return m;
-	}
+                return m;
+        }
 
         /**
          * Creates a nested <code>tag</code> task.

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/MergeTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/MergeTask.java
@@ -15,11 +15,12 @@
  */
 package com.rimerosolutions.ant.git.tasks;
 
-import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
-import com.rimerosolutions.ant.git.GitBuildException;
 import org.apache.tools.ant.BuildException;
 import org.eclipse.jgit.api.MergeCommand;
 import org.eclipse.jgit.api.MergeResult;
+
+import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
+import com.rimerosolutions.ant.git.GitBuildException;
 
 /**
  * Merge changes from a repository.

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/MergeTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/MergeTask.java
@@ -36,57 +36,57 @@ import org.eclipse.jgit.api.MergeResult;
  */
 public class MergeTask extends AbstractGitRepoAwareTask {
 
-	private static final String TASK_NAME = "git-merge";
-	private static final String MESSAGE_MERGE_FAILED = "Merge failed.";
-	private static final String MESSAGE_MERGE_FAILED_WITH_STATUS = "Merge failed, status '%s'.";
-	private static final String MESSAGE_MERGE_FAILED_WITH_URI = "Could not merge from uri '%s'.";
-	private boolean squash = false;
-	private String branchname = null;
+        private static final String TASK_NAME = "git-merge";
+        private static final String MESSAGE_MERGE_FAILED = "Merge failed.";
+        private static final String MESSAGE_MERGE_FAILED_WITH_STATUS = "Merge failed, status '%s'.";
+        private static final String MESSAGE_MERGE_FAILED_WITH_URI = "Could not merge from uri '%s'.";
+        private boolean squash = false;
+        private String branchname = null;
 
-	@Override
-	public String getName() {
-		return TASK_NAME;
-	}
+        @Override
+        public String getName() {
+                return TASK_NAME;
+        }
 
-	/**
-	* Set if merge should be squashed
-	*
-	* @param squash Whether or not to squash
-	* @antdoc.notrequired
-	*/
-	public void setSquash(boolean squash) {
-		this.squash = squash;
-	}
+        /**
+        * Set if merge should be squashed
+        *
+        * @param squash Whether or not to squash
+        * @antdoc.notrequired
+        */
+        public void setSquash(boolean squash) {
+                this.squash = squash;
+        }
 
-	/**
-	 * Set branch to merge
-	 *
-	 * @param branchname Branch to merge
-	 */
-	public void setBranchname(String branchname) {
-		this.branchname = branchname;
-	}
+        /**
+         * Set branch to merge
+         *
+         * @param branchname Branch to merge
+         */
+        public void setBranchname(String branchname) {
+                this.branchname = branchname;
+        }
 
-	@Override
-	public void doExecute() {
-		try {
-			MergeCommand mergeCommand = git.merge().setSquash(squash);
-			mergeCommand.include(mergeCommand.getRepository().getRef(branchname));
+        @Override
+        public void doExecute() {
+                try {
+                        MergeCommand mergeCommand = git.merge().setSquash(squash);
+                        mergeCommand.include(mergeCommand.getRepository().getRef(branchname));
 
-			setupCredentials(mergeCommand);
-			MergeResult mergeResult = mergeCommand.call();
+                        setupCredentials(mergeCommand);
+                        MergeResult mergeResult = mergeCommand.call();
 
-			if (!mergeResult.getMergeStatus().isSuccessful()) {
+                        if (!mergeResult.getMergeStatus().isSuccessful()) {
 
-				if (mergeResult.getFailingPaths() != null && mergeResult.getFailingPaths().size() > 0) {
-					throw new BuildException(String.format("%s - Failing paths: %s", MESSAGE_MERGE_FAILED, mergeResult.getFailingPaths()));
-				}
+                                if (mergeResult.getFailingPaths() != null && mergeResult.getFailingPaths().size() > 0) {
+                                        throw new BuildException(String.format("%s - Failing paths: %s", MESSAGE_MERGE_FAILED, mergeResult.getFailingPaths()));
+                                }
 
-				throw new BuildException(String.format(MESSAGE_MERGE_FAILED_WITH_STATUS, mergeResult.getMergeStatus().name()));
-			}
-		} catch (Exception e) {
-			throw new GitBuildException(String.format(MESSAGE_MERGE_FAILED_WITH_URI, getUri()), e);
-		}
-	}
+                                throw new BuildException(String.format(MESSAGE_MERGE_FAILED_WITH_STATUS, mergeResult.getMergeStatus().name()));
+                        }
+                } catch (Exception e) {
+                        throw new GitBuildException(String.format(MESSAGE_MERGE_FAILED_WITH_URI, getUri()), e);
+                }
+        }
 
 }

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
@@ -52,7 +52,7 @@ public class PushTask extends AbstractGitRepoAwareTask {
         private String pushFailedProperty;
         private boolean includeTags = true;
         private static final String TASK_NAME = "git-push";
-	private static final String PUSH_REJECTED_MESSAGE = "Push rejected.";
+        private static final String PUSH_REJECTED_MESSAGE = "Push rejected.";
         private static final String PUSH_FAILED_MESSAGE = "Push failed.";
         private static final String DEFAULT_REFSPEC_STRING = "+" + Constants.R_HEADS + "*:" + Constants.R_REMOTES + Constants.DEFAULT_REMOTE_NAME + "/*";
 
@@ -104,9 +104,9 @@ public class PushTask extends AbstractGitRepoAwareTask {
                         List<RefSpec> specs = Arrays.asList(new RefSpec(currentBranch + ":" + currentBranch));
 
                         PushCommand pushCommand = git.push().
-                                setPushAll().
-                                setRefSpecs(specs).
-                                setDryRun(false);
+                                        setPushAll().
+                                        setRefSpecs(specs).
+                                        setDryRun(false);
 
                         if (getUri() != null) {
                                 pushCommand.setRemote(getUri());
@@ -124,17 +124,17 @@ public class PushTask extends AbstractGitRepoAwareTask {
 
                         Iterable<PushResult> pushResults = pushCommand.setForce(true).call();
 
-			boolean rejected = false;
+                        boolean rejected = false;
                         for (PushResult pushResult : pushResults) {
                                 GitTaskUtils.validateTrackingRefUpdates(PUSH_FAILED_MESSAGE, pushResult.getTrackingRefUpdates());
-				String messages = pushResult.getMessages();
-				log(messages);
-				if (messages.contains(PUSH_REJECTED_MESSAGE)) {
-					rejected = true;
-				}
-			}
-			if (rejected) {
-				throw new Exception(PUSH_REJECTED_MESSAGE);
+                                String messages = pushResult.getMessages();
+                                log(messages);
+                                if (messages.contains(PUSH_REJECTED_MESSAGE)) {
+                                        rejected = true;
+                                }
+                        }
+                        if (rejected) {
+                                throw new Exception(PUSH_REJECTED_MESSAGE);
                         }
                 } catch (Exception e) {
                         if (pushFailedProperty != null) {

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
@@ -52,6 +52,7 @@ public class PushTask extends AbstractGitRepoAwareTask {
 
         private String pushFailedProperty;
         private boolean includeTags = true;
+        private String deleteRemoteBranch;
         private static final String TASK_NAME = "git-push";
         private static final String PUSH_FAILED_MESSAGE = "Push failed.";
         private static final String DEFAULT_REFSPEC_STRING = "+" + Constants.R_HEADS + "*:" + Constants.R_REMOTES + Constants.DEFAULT_REMOTE_NAME + "/*";
@@ -81,6 +82,15 @@ public class PushTask extends AbstractGitRepoAwareTask {
                 this.pushFailedProperty = pushFailedProperty;
         }
 
+        /**
+         * Sets a remote branch to delete.
+         * @antdoc.notrequired
+         * @param deleteRemoteBranch Locally deleted branch to delete remotely
+         */
+        public void setDeleteRemoteBranch(String deleteRemoteBranch) {
+                this.deleteRemoteBranch = deleteRemoteBranch;
+        }
+
         @Override
         protected void doExecute() {
                 try {
@@ -102,6 +112,10 @@ public class PushTask extends AbstractGitRepoAwareTask {
 
                         String currentBranch = git.getRepository().getBranch();
                         List<RefSpec> specs = Arrays.asList(new RefSpec(currentBranch + ":" + currentBranch));
+
+                        if (deleteRemoteBranch != null) {
+                                specs = Arrays.asList(new RefSpec(":" + Constants.R_HEADS + deleteRemoteBranch));
+                        }
 
                         PushCommand pushCommand = git.push().
                                         setPushAll().

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
@@ -18,9 +18,6 @@ package com.rimerosolutions.ant.git.tasks;
 import java.util.Arrays;
 import java.util.List;
 
-import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
-import com.rimerosolutions.ant.git.GitBuildException;
-import com.rimerosolutions.ant.git.GitTaskUtils;
 import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.StoredConfig;
@@ -28,6 +25,10 @@ import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
+
+import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
+import com.rimerosolutions.ant.git.GitBuildException;
+import com.rimerosolutions.ant.git.GitTaskUtils;
 
 /**
  * Push changes to a remote repository.

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
@@ -52,7 +52,6 @@ public class PushTask extends AbstractGitRepoAwareTask {
         private String pushFailedProperty;
         private boolean includeTags = true;
         private static final String TASK_NAME = "git-push";
-        private static final String PUSH_REJECTED_MESSAGE = "Push rejected.";
         private static final String PUSH_FAILED_MESSAGE = "Push failed.";
         private static final String DEFAULT_REFSPEC_STRING = "+" + Constants.R_HEADS + "*:" + Constants.R_REMOTES + Constants.DEFAULT_REMOTE_NAME + "/*";
 
@@ -124,17 +123,10 @@ public class PushTask extends AbstractGitRepoAwareTask {
 
                         Iterable<PushResult> pushResults = pushCommand.setForce(true).call();
 
-                        boolean rejected = false;
                         for (PushResult pushResult : pushResults) {
+                                log(pushResult.getMessages());
+                                GitTaskUtils.validateRemoteRefUpdates(PUSH_FAILED_MESSAGE, pushResult.getRemoteUpdates());
                                 GitTaskUtils.validateTrackingRefUpdates(PUSH_FAILED_MESSAGE, pushResult.getTrackingRefUpdates());
-                                String messages = pushResult.getMessages();
-                                log(messages);
-                                if (messages.contains(PUSH_REJECTED_MESSAGE)) {
-                                        rejected = true;
-                                }
-                        }
-                        if (rejected) {
-                                throw new Exception(PUSH_REJECTED_MESSAGE);
                         }
                 } catch (Exception e) {
                         if (pushFailedProperty != null) {

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/TagTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/TagTask.java
@@ -15,12 +15,13 @@
  */
 package com.rimerosolutions.ant.git.tasks;
 
+import org.eclipse.jgit.api.errors.GitAPIException;
+
 import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
 import com.rimerosolutions.ant.git.GitBuildException;
 import com.rimerosolutions.ant.git.GitSettings;
 import com.rimerosolutions.ant.git.GitTaskUtils;
 import com.rimerosolutions.ant.git.MissingRequiredGitSettingsException;
-import org.eclipse.jgit.api.errors.GitAPIException;
 
 /**
  * Create a git tag.

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/TagTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/TagTask.java
@@ -15,14 +15,12 @@
  */
 package com.rimerosolutions.ant.git.tasks;
 
-import com.rimerosolutions.ant.git.GitSettings;
-import com.rimerosolutions.ant.git.MissingRequiredGitSettingsException;
-
-import org.eclipse.jgit.api.errors.GitAPIException;
-
 import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
 import com.rimerosolutions.ant.git.GitBuildException;
+import com.rimerosolutions.ant.git.GitSettings;
 import com.rimerosolutions.ant.git.GitTaskUtils;
+import com.rimerosolutions.ant.git.MissingRequiredGitSettingsException;
+import org.eclipse.jgit.api.errors.GitAPIException;
 
 /**
  * Create a git tag.
@@ -83,7 +81,7 @@ public class TagTask extends AbstractGitRepoAwareTask {
                 if (gitSettings == null) {
                         throw new MissingRequiredGitSettingsException();
                 }
-                
+
                 try {
                         git.tag().setName(name).setTagger(gitSettings.getIdentity()).setMessage(message).call();
                 } catch (GitAPIException ex) {


### PR DESCRIPTION
The main point of this PR is GitTaskUtils.validateRemoteRefUpdates, but there are also some formatting (I've tried to align with you, but I guess some of my earlier sins were merged into your codebase).
I also fixed newlines (I'm on Windows) so the diffs should work better (although GitTasks and TagTask don't)!