### PR TITLE
Ability to set refSpecs on fetch and push

### DIFF
--- a/src/main/java/com/rimerosolutions/ant/git/tasks/FetchTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/FetchTask.java
@@ -47,6 +47,7 @@ import com.rimerosolutions.ant.git.GitTaskUtils;
 public class FetchTask extends AbstractGitRepoAwareTask {
 
         private boolean dryRun = false;
+        private String remoteRefSpec = "+" + Constants.R_HEADS + "*:" + Constants.R_REMOTES + Constants.DEFAULT_REMOTE_NAME + "/*";
         private boolean removeDeletedRefs = true;
         private boolean thinPack = true;
         private static final String TASK_NAME = "git-fetch";
@@ -65,6 +66,16 @@ public class FetchTask extends AbstractGitRepoAwareTask {
          */
         public void setThinPack(boolean thinPack) {
                 this.thinPack = thinPack;
+        }
+        
+        /**
+         * Sets the remote refSpec preference for fetch operation.
+         *
+         * @antdoc.notrequired
+         * @param remoteRefSpec (Default value is '+/refs/heads/*:refs/remote/origin/*' )
+         */
+        public void setRemoteRefSpec(String remoteRefSpec) {
+                this.remoteRefSpec = remoteRefSpec;
         }
 
         /**
@@ -109,7 +120,7 @@ public class FetchTask extends AbstractGitRepoAwareTask {
 
                         List<RefSpec> specs = new ArrayList<RefSpec>(3);
 
-                        specs.add(new RefSpec("+" + Constants.R_HEADS + "*:" + Constants.R_REMOTES + Constants.DEFAULT_REMOTE_NAME + "/*"));
+                        specs.add(new RefSpec(remoteRefSpec));
                         specs.add(new RefSpec("+" + Constants.R_NOTES + "*:" + Constants.R_NOTES + "*"));
                         specs.add(new RefSpec("+" + Constants.R_TAGS + "*:" + Constants.R_TAGS + "*"));
 

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/FetchTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/FetchTask.java
@@ -15,22 +15,22 @@
  */
 package com.rimerosolutions.ant.git.tasks;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.net.URISyntaxException;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jgit.api.FetchCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.lib.ConfigConstants;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.transport.FetchResult;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.StoredConfig;
-import org.eclipse.jgit.lib.ConfigConstants;
-import org.eclipse.jgit.api.errors.InvalidRemoteException;
-import org.eclipse.jgit.api.errors.TransportException;
-import org.eclipse.jgit.api.errors.GitAPIException;
 
 import com.rimerosolutions.ant.git.AbstractGitRepoAwareTask;
 import com.rimerosolutions.ant.git.GitBuildException;
@@ -50,6 +50,7 @@ public class FetchTask extends AbstractGitRepoAwareTask {
         private String remoteRefSpec = "+" + Constants.R_HEADS + "*:" + Constants.R_REMOTES + Constants.DEFAULT_REMOTE_NAME + "/*";
         private boolean removeDeletedRefs = true;
         private boolean thinPack = true;
+        private boolean defaultRefSpecs = true;
         private static final String TASK_NAME = "git-fetch";
         private static final String FETCH_FAILED_MESSAGE = "Fetch failed";
 
@@ -67,12 +68,14 @@ public class FetchTask extends AbstractGitRepoAwareTask {
         public void setThinPack(boolean thinPack) {
                 this.thinPack = thinPack;
         }
-        
+
         /**
          * Sets the remote refSpec preference for fetch operation.
          *
          * @antdoc.notrequired
          * @param remoteRefSpec (Default value is '+/refs/heads/*:refs/remote/origin/*' )
+         *
+         * One is able to provide an null or empty string to not set any refSpec.
          */
         public void setRemoteRefSpec(String remoteRefSpec) {
                 this.remoteRefSpec = remoteRefSpec;
@@ -98,6 +101,17 @@ public class FetchTask extends AbstractGitRepoAwareTask {
                 this.dryRun = dryRun;
         }
 
+        /**
+         * If set to true, the following additional refs are also fetched:
+         * +/refs/notes/*:refs/notes/* and +/refs/tags/*:refs/tags/*
+         *
+         * @antdoc.notrequired
+         * @param defaultRefSpecs (Default value is true)
+         */
+        public void setDefaultRefSpecs(boolean defaultRefSpecs) {
+                this.defaultRefSpecs  = defaultRefSpecs;
+        }
+
         @Override
         public void doExecute() {
                 try {
@@ -120,9 +134,13 @@ public class FetchTask extends AbstractGitRepoAwareTask {
 
                         List<RefSpec> specs = new ArrayList<RefSpec>(3);
 
-                        specs.add(new RefSpec(remoteRefSpec));
-                        specs.add(new RefSpec("+" + Constants.R_NOTES + "*:" + Constants.R_NOTES + "*"));
-                        specs.add(new RefSpec("+" + Constants.R_TAGS + "*:" + Constants.R_TAGS + "*"));
+                        if (null != remoteRefSpec && remoteRefSpec != "") {
+                            specs.add(new RefSpec(remoteRefSpec));
+                        }
+                        if (defaultRefSpecs) {
+                            specs.add(new RefSpec("+" + Constants.R_NOTES + "*:" + Constants.R_NOTES + "*"));
+                            specs.add(new RefSpec("+" + Constants.R_TAGS + "*:" + Constants.R_TAGS + "*"));
+                        }
 
                         FetchCommand fetchCommand = git.fetch().
                                 setDryRun(dryRun).

--- a/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
+++ b/src/main/java/com/rimerosolutions/ant/git/tasks/PushTask.java
@@ -15,6 +15,7 @@
  */
 package com.rimerosolutions.ant.git.tasks;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,6 +55,7 @@ public class PushTask extends AbstractGitRepoAwareTask {
         private boolean includeTags = true;
         private boolean forcePush = false;
         private String deleteRemoteBranch;
+        private String remoteRefSpec;
         private static final String TASK_NAME = "git-push";
         private static final String PUSH_FAILED_MESSAGE = "Push failed.";
         private static final String DEFAULT_REFSPEC_STRING = "+" + Constants.R_HEADS + "*:" + Constants.R_REMOTES + Constants.DEFAULT_REMOTE_NAME + "/*";
@@ -100,6 +102,18 @@ public class PushTask extends AbstractGitRepoAwareTask {
                 this.deleteRemoteBranch = deleteRemoteBranch;
         }
 
+        /**
+         * Sets the remote refSpec preference for push operation.
+         *
+         * @antdoc.notrequired
+         * @param remoteRefSpec (Default value is '+/refs/heads/*:refs/remote/origin/*' )
+         *
+         * One is able to provide an null or empty string to not set any refSpec.
+         */
+        public void setRemoteRefSpec(String remoteRefSpec) {
+                this.remoteRefSpec  = remoteRefSpec;
+        }
+
         @Override
         protected void doExecute() {
                 try {
@@ -119,8 +133,10 @@ public class PushTask extends AbstractGitRepoAwareTask {
                                 config.save();
                         }
 
-                        String currentBranch = git.getRepository().getBranch();
-                        List<RefSpec> specs = Arrays.asList(new RefSpec(currentBranch + ":" + currentBranch));
+                        List<RefSpec> specs = new ArrayList<RefSpec>();
+                        if (null != remoteRefSpec && remoteRefSpec != "") {
+                            specs.add(new RefSpec(remoteRefSpec));
+                        }
 
                         if (deleteRemoteBranch != null) {
                                 specs = Arrays.asList(new RefSpec(":" + Constants.R_HEADS + deleteRemoteBranch));


### PR DESCRIPTION
Hi, this pull request contains changes from Luca Matteu and me. With this pull request merged it's possible to set refSpecs on fetch and pull. It's also possible to disable default refSpecs set on fetch operation.
We need this, because JGit is not able to push a branch and a tag with the same name, with the default refSpec.